### PR TITLE
Change vdpm build options

### DIFF
--- a/scripts/007-vdpm.sh
+++ b/scripts/007-vdpm.sh
@@ -15,3 +15,4 @@ cd ${VDPM}
 
 ## Compile and install.
 cp config.sample config && ./install-all.sh
+cp config.travis config && ./vdpm -i freetype


### PR DESCRIPTION
current prebuilt tarballs have insane directory path
but actually only impact freetype

this patch is temporary fix until https://github.com/vitasdk/vdpm/issues/1